### PR TITLE
Add hostname option and QUAY_HOSTNAME

### DIFF
--- a/command/create.go
+++ b/command/create.go
@@ -34,7 +34,7 @@ func (c *CreateCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "Created! quay.io/%v/%v\n", repos.Namespace, repos.Name)
+	fmt.Fprintf(os.Stdout, "Created! %v/%v/%v\n", hostname, repos.Namespace, repos.Name)
 
 	return 0
 }

--- a/command/create.go
+++ b/command/create.go
@@ -29,7 +29,7 @@ func (c *CreateCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	repos, err := quay.CreateRepository(ss[0], ss[1], visibility)
+	repos, err := quay.CreateRepository(ss[0], ss[1], visibility, hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)

--- a/command/delete.go
+++ b/command/delete.go
@@ -24,7 +24,7 @@ func (c *DeleteCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	err := quay.DeleteRepository(ss[0], ss[1])
+	err := quay.DeleteRepository(ss[0], ss[1], hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)

--- a/command/delete.go
+++ b/command/delete.go
@@ -29,7 +29,7 @@ func (c *DeleteCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "Deleted! quay.io/%v/%v\n", ss[0], ss[1])
+	fmt.Fprintf(os.Stdout, "Deleted! %v/%v/%v\n", hostname, ss[0], ss[1])
 	return 0
 }
 

--- a/command/flag.go
+++ b/command/flag.go
@@ -8,6 +8,7 @@ var (
 	role       string
 	visibility string
 	public     bool
+	hostname   string
 )
 
 func FlagInit(args []string) error {
@@ -20,6 +21,7 @@ func FlagInit(args []string) error {
 	flags.StringVar(&visibility, "visibility", "public", "visibility set to 'public' or 'private'.")
 	flags.StringVar(&role, "role", "read", "role to use for the user =  ['read', 'write', 'admin'].")
 	flags.BoolVar(&public, "is-public", true, "'--is-public=true' or '--is-public=false'.")
+	flags.StringVar(&hostname, "hostname", "quay.io", "If you use enterprise plan, set hostname option. ex '--hostname=quay.example.com'")
 
 	if err := flags.Parse(args[0:]); err != nil {
 		return err

--- a/command/get.go
+++ b/command/get.go
@@ -24,7 +24,7 @@ func (c *GetCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	repos, err := quay.GetRepository(ss[0], ss[1])
+	repos, err := quay.GetRepository(ss[0], ss[1], hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
@@ -41,7 +41,7 @@ func (c *GetCommand) Run(args []string) int {
 	}
 	fmt.Fprintln(os.Stdout, "Permissions:")
 
-	permissions, err := quay.GetPermissions(ss[0], ss[1], "user")
+	permissions, err := quay.GetPermissions(ss[0], ss[1], "user", hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
@@ -50,7 +50,7 @@ func (c *GetCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stdout, "\t%v(%v)\n", p.Name, p.Role)
 	}
 
-	permissions, err = quay.GetPermissions(ss[0], ss[1], "team")
+	permissions, err = quay.GetPermissions(ss[0], ss[1], "team", hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)

--- a/command/get.go
+++ b/command/get.go
@@ -31,7 +31,7 @@ func (c *GetCommand) Run(args []string) int {
 	}
 
 	fmt.Fprintln(os.Stdout, "Repository:")
-	fmt.Fprintf(os.Stdout, "\tquay.io/%v/%v\n", repos.Namespace, repos.Name)
+	fmt.Fprintf(os.Stdout, "\t%v/%v/%v\n", hostname, repos.Namespace, repos.Name)
 
 	fmt.Fprintln(os.Stdout, "Visibility:")
 	if repos.IsPublic == true {

--- a/command/list.go
+++ b/command/list.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/koudaiii/qucli/quay"
 	"strconv"
+
+	"github.com/koudaiii/qucli/quay"
 )
 
 type ListCommand struct {
@@ -40,7 +41,7 @@ func (c *ListCommand) Run(args []string) int {
 
 	for _, repos := range repositories.Items {
 		fmt.Fprintln(repositoryPrint, strings.Join(
-			[]string{"quay.io/" + repos.Namespace + "/" + repos.Name, strconv.FormatBool(repos.IsPublic), repos.Description}, "\t",
+			[]string{hostname + "/" + repos.Namespace + "/" + repos.Name, strconv.FormatBool(repos.IsPublic), repos.Description}, "\t",
 		))
 	}
 	repositoryPrint.Flush()

--- a/command/list.go
+++ b/command/list.go
@@ -27,7 +27,7 @@ func (c *ListCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	repositories, err := quay.ListRepository(args[0], public)
+	repositories, err := quay.ListRepository(args[0], public, hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)

--- a/command/team.go
+++ b/command/team.go
@@ -33,7 +33,7 @@ func (c *AddTeamCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	repos, err := quay.AddPermission(ss[0], ss[1], "team", args[1], role)
+	repos, err := quay.AddPermission(ss[0], ss[1], "team", args[1], role, hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
@@ -67,7 +67,7 @@ func (c *DeleteTeamCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	err := quay.DeletePermission(ss[0], ss[1], "team", args[1])
+	err := quay.DeletePermission(ss[0], ss[1], "team", args[1], hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)

--- a/command/team.go
+++ b/command/team.go
@@ -38,7 +38,7 @@ func (c *AddTeamCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "Added! %v(%v) in quay.io/%v/%v\n", repos.Name, repos.Role, ss[0], ss[1])
+	fmt.Fprintf(os.Stdout, "Added! %v(%v) in %v/%v/%v\n", repos.Name, repos.Role, hostname, ss[0], ss[1])
 	return 0
 }
 
@@ -72,7 +72,7 @@ func (c *DeleteTeamCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "Deleted! %v in quay.io/%v/%v\n", args[1], ss[0], ss[1])
+	fmt.Fprintf(os.Stdout, "Deleted! %v in %v/%v/%v\n", args[1], hostname, ss[0], ss[1])
 	return 0
 }
 

--- a/command/user.go
+++ b/command/user.go
@@ -33,7 +33,7 @@ func (c *AddUserCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	repos, err := quay.AddPermission(ss[0], ss[1], "user", args[1], role)
+	repos, err := quay.AddPermission(ss[0], ss[1], "user", args[1], role, hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
@@ -67,7 +67,7 @@ func (c *DeleteUserCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
-	err := quay.DeletePermission(ss[0], ss[1], "user", args[1])
+	err := quay.DeletePermission(ss[0], ss[1], "user", args[1], hostname)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)

--- a/command/user.go
+++ b/command/user.go
@@ -38,7 +38,7 @@ func (c *AddUserCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "Added! %v(%v) in quay.io/%v/%v\n", repos.Name, repos.Role, ss[0], ss[1])
+	fmt.Fprintf(os.Stdout, "Added! %v(%v) in %v/%v/%v\n", repos.Name, repos.Role, hostname, ss[0], ss[1])
 	return 0
 }
 
@@ -72,7 +72,7 @@ func (c *DeleteUserCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stdout, "Deleted! %v in quay.io/%v/%v\n", args[1], ss[0], ss[1])
+	fmt.Fprintf(os.Stdout, "Deleted! %v in %v/%v/%v\n", args[1], hostname, ss[0], ss[1])
 	return 0
 }
 

--- a/quay/permission.go
+++ b/quay/permission.go
@@ -2,22 +2,17 @@ package quay
 
 import (
 	"encoding/json"
-	"net/url"
 	"os"
 	"path"
 
 	"github.com/koudaiii/qucli/utils"
 )
 
-func GetPermissions(namespace string, name string, accountType string) (QuayPermissions, error) {
+func GetPermissions(namespace string, name string, accountType string, hostname string) (QuayPermissions, error) {
 	var resp QuayPermissionsResponse
 	var permissions QuayPermissions
 
-	u, err := url.Parse(QuayURLBase)
-
-	if err != nil {
-		return permissions, err
-	}
+	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "permissions", accountType) + "/"
 
 	body, err := utils.HttpGet(u.String(), os.Getenv("QUAY_API_TOKEN"))
@@ -37,14 +32,11 @@ func GetPermissions(namespace string, name string, accountType string) (QuayPerm
 	return permissions, nil
 }
 
-func DeletePermission(namespace string, name string, accountType string, account string) error {
-	u, err := url.Parse(QuayURLBase)
-	if err != nil {
-		return err
-	}
+func DeletePermission(namespace string, name string, accountType string, account string, hostname string) error {
+	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "permissions", accountType, account)
 
-	_, err = utils.HttpDelete(u.String(), os.Getenv("QUAY_API_TOKEN"))
+	_, err := utils.HttpDelete(u.String(), os.Getenv("QUAY_API_TOKEN"))
 	if err != nil {
 		return err
 	}
@@ -52,17 +44,14 @@ func DeletePermission(namespace string, name string, accountType string, account
 	return nil
 }
 
-func AddPermission(namespace string, name string, accountType string, account string, role string) (QuayPermission, error) {
+func AddPermission(namespace string, name string, accountType string, account string, role string, hostname string) (QuayPermission, error) {
 	var repos QuayPermission
 	var permission QuayPermission
 	req, err := json.Marshal(QuayPermission{
 		Role: role,
 	})
 
-	u, err := url.Parse(QuayURLBase)
-	if err != nil {
-		return permission, err
-	}
+	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "permissions", accountType, account)
 
 	body, err := utils.HttpPut(u.String(), os.Getenv("QUAY_API_TOKEN"), req)

--- a/quay/quay.go
+++ b/quay/quay.go
@@ -47,6 +47,9 @@ type RequestRepository struct {
 }
 
 func QuayURLParse(hostname string) *url.URL {
+	if os.Getenv("QUAY_HOSTNAME") != "" {
+		hostname = os.Getenv("QUAY_HOSTNAME")
+	}
 	u, err := url.Parse("https://" + hostname + "/api/v1/")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "err: %v\n", err)

--- a/quay/quay.go
+++ b/quay/quay.go
@@ -1,6 +1,10 @@
 package quay
 
-const QuayURLBase = "https://quay.io/api/v1/"
+import (
+	"fmt"
+	"net/url"
+	"os"
+)
 
 type QuayPermission struct {
 	Name string `json:"name"`
@@ -40,4 +44,13 @@ type RequestRepository struct {
 	Visibility  string `json:"visibility"`
 	Repository  string `json:"repository"`
 	Description string `json:"description"`
+}
+
+func QuayURLParse(hostname string) *url.URL {
+	u, err := url.Parse("https://" + hostname + "/api/v1/")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "err: %v\n", err)
+		os.Exit(1)
+	}
+	return u
 }

--- a/quay/repository.go
+++ b/quay/repository.go
@@ -10,13 +10,10 @@ import (
 	"github.com/koudaiii/qucli/utils"
 )
 
-func ListRepository(namespace string, public bool) (QuayRepositories, error) {
+func ListRepository(namespace string, public bool, hostname string) (QuayRepositories, error) {
 	var repos ResponseRepositories
 	var repositories QuayRepositories
-	u, err := url.Parse(QuayURLBase)
-	if err != nil {
-		return repositories, err
-	}
+	u := QuayURLParse(hostname)
 
 	values := url.Values{}
 	values.Set("public", strconv.FormatBool(public))
@@ -44,12 +41,9 @@ func ListRepository(namespace string, public bool) (QuayRepositories, error) {
 	return repositories, nil
 }
 
-func GetRepository(namespace string, name string) (ResponseRepository, error) {
+func GetRepository(namespace string, name string, hostname string) (ResponseRepository, error) {
 	var repos ResponseRepository
-	u, err := url.Parse(QuayURLBase)
-	if err != nil {
-		return repos, err
-	}
+	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name)
 
 	body, err := utils.HttpGet(u.String(), os.Getenv("QUAY_API_TOKEN"))
@@ -64,14 +58,11 @@ func GetRepository(namespace string, name string) (ResponseRepository, error) {
 	return repos, nil
 }
 
-func DeleteRepository(namespace string, name string) error {
-	u, err := url.Parse(QuayURLBase)
-	if err != nil {
-		return err
-	}
+func DeleteRepository(namespace string, name string, hostname string) error {
+	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name)
 
-	_, err = utils.HttpDelete(u.String(), os.Getenv("QUAY_API_TOKEN"))
+	_, err := utils.HttpDelete(u.String(), os.Getenv("QUAY_API_TOKEN"))
 	if err != nil {
 		return err
 	}
@@ -79,7 +70,7 @@ func DeleteRepository(namespace string, name string) error {
 	return nil
 }
 
-func CreateRepository(namespace string, name string, visibility string) (QuayRepository, error) {
+func CreateRepository(namespace string, name string, visibility string, hostname string) (QuayRepository, error) {
 	var repos QuayRepository
 	req, err := json.Marshal(RequestRepository{
 		Namespace:  namespace,
@@ -87,10 +78,7 @@ func CreateRepository(namespace string, name string, visibility string) (QuayRep
 		Visibility: visibility,
 	})
 
-	u, err := url.Parse(QuayURLBase)
-	if err != nil {
-		return repos, err
-	}
+	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository")
 
 	body, err := utils.HttpPost(u.String(), os.Getenv("QUAY_API_TOKEN"), req)


### PR DESCRIPTION
## REF
#22 

## WHY

QuayURL is hard coding now. If you use Quay Enterprise, you can not use qucli command 😢 

Fix #22.

## WHAT

add `--hostname` option(default: quay.io)
