### PR TITLE
Bump up to golang 1.8 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,16 @@ deploy:
     on:
       repo: koudaiii/qucli
       tags: true
-      go: '1.7'
+      go: '1.8'
   - provider: script
     skip_cleanup: true
     script: make ci-docker-release
     on:
       branch: master
-      go: '1.7'
+      go: '1.8'
   - provider: script
     skip_cleanup: true
     script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release
     on:
       tags: true
-      go: '1.7'
+      go: '1.8'


### PR DESCRIPTION
## WHY

see https://travis-ci.org/koudaiii/qucli/builds/289491760

```
Skipping a deployment with the releases provider because this is not on the required runtime
Skipping a deployment with the script provider because this branch is not permitted
Skipping a deployment with the script provider because this is not on the required runtime
Skipping a deployment with the script provider because this is not on the required runtime
```

## WHAT

Bump up to golang 1.8
