### PR TITLE
Add validate

### DIFF
--- a/command/notification.go
+++ b/command/notification.go
@@ -37,6 +37,13 @@ func (c *AddNotificationCommand) Run(args []string) int {
 		os.Exit(1)
 	}
 
+	// if you use add-notification command, you must set 'event' option and 'method' option.
+	if event == "" || method == "" {
+		fmt.Fprintln(os.Stderr, "if you use add-notification command, you must set 'event' option and 'method' option.")
+		fmt.Fprintln(os.Stderr, c.Help())
+		os.Exit(1)
+	}
+
 	// if you use 'vulnerability_found' event, you need set 'level' option.
 	if event == "vulnerability_found" && level == "" {
 		fmt.Fprintln(os.Stderr, "if you use 'vulnerability_found' event, you need set 'level' option.")


### PR DESCRIPTION
## WHY

```shell-session
$ qucli add-notification koudaiii/test
err: HTTP error!
URL: https://quay.io/api/v1/repository/koudaiii/test/notification/
status code: 400
body:
{"status": 400, "error_message": "'event' is a required property", "title": "invalid_request", "error_type": "invalid_request", "detail": "'event' is a required property", "type": "https://quay.io/api/v1/error/invalid_request"}
```

if you use add-notification command, you must set 'event' option and 'method' option.

## WHAT

Add check `event` and `method` options.
