### PR TITLE
FIix CI: unknown shorthand flag: 'e' in -e=[secure]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bin/$(NAME): $(SRCS)
 
 .PHONY: ci-docker-release
 ci-docker-release: docker-build
-	@docker login -e="$(DOCKER_QUAY_EMAIL)" -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
+	@docker login -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
 	docker push $(DOCKER_IMAGE)
 
 .PHONY: clean


### PR DESCRIPTION
## Why

ref. https://travis-ci.org/koudaiii/qucli/builds/512453422#L686

koudaiii/qucli of master failed.

## What

Fix