### PR TITLE
Default not use `HOSTNAME` env

### DIFF
--- a/quay/notification.go
+++ b/quay/notification.go
@@ -15,7 +15,7 @@ func ListRepositoryNotifications(namespace string, name string, hostname string)
 
 	u.Path = path.Join(u.Path, "repository", namespace, name, "notification")
 
-	body, err := utils.HttpGet(u.String(), config.APIToken)
+	body, err := utils.HttpGet(u.String(), config.QuayAPIToken)
 	if err != nil {
 		return notifications, err
 	}
@@ -47,7 +47,7 @@ func DeleteRepositoryNotification(namespace string, name string, uuid string, ho
 
 	u.Path = path.Join(u.Path, "repository", namespace, name, "notification", uuid)
 
-	_, err := utils.HttpDelete(u.String(), config.APIToken)
+	_, err := utils.HttpDelete(u.String(), config.QuayAPIToken)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func AddRepositoryNotification(namespace string, name string, request RequestRep
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "notification")
 
-	body, err := utils.HttpPost(u.String()+"/", config.APIToken, req)
+	body, err := utils.HttpPost(u.String()+"/", config.QuayAPIToken, req)
 	if err != nil {
 		return repos, err
 	}
@@ -79,7 +79,7 @@ func TestRepositoryNotification(namespace string, name string, uuid string, host
 
 	u.Path = path.Join(u.Path, "repository", namespace, name, "notification", uuid, "test")
 
-	_, err := utils.HttpPost(u.String(), config.APIToken, nil)
+	_, err := utils.HttpPost(u.String(), config.QuayAPIToken, nil)
 	if err != nil {
 		return err
 	}

--- a/quay/permission.go
+++ b/quay/permission.go
@@ -14,7 +14,7 @@ func GetPermissions(namespace string, name string, accountType string, hostname 
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "permissions", accountType) + "/"
 
-	body, err := utils.HttpGet(u.String(), config.APIToken)
+	body, err := utils.HttpGet(u.String(), config.QuayAPIToken)
 	if err != nil {
 		return permissions, err
 	}
@@ -35,7 +35,7 @@ func DeletePermission(namespace string, name string, accountType string, account
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "permissions", accountType, account)
 
-	_, err := utils.HttpDelete(u.String(), config.APIToken)
+	_, err := utils.HttpDelete(u.String(), config.QuayAPIToken)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func AddPermission(namespace string, name string, accountType string, account st
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name, "permissions", accountType, account)
 
-	body, err := utils.HttpPut(u.String(), config.APIToken, req)
+	body, err := utils.HttpPut(u.String(), config.QuayAPIToken, req)
 	if err != nil {
 		return repos, err
 	}

--- a/quay/quay.go
+++ b/quay/quay.go
@@ -9,19 +9,15 @@ import (
 )
 
 type Config struct {
-	Hostname string `envconfig:"HOSTNAME"`
-	APIToken string `envconfig:"API_TOKEN"`
+	QuayHostname string `envconfig:"QUAY_HOSTNAME"`
+	QuayAPIToken string `envconfig:"QUAY_API_TOKEN"`
 }
-
-const (
-	appName = "quay"
-)
 
 var config *Config
 
 func init() {
 	c := &Config{}
-	if err := envconfig.Process(appName, c); err != nil {
+	if err := envconfig.Process("", c); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
 	config = c
@@ -104,8 +100,8 @@ type RequestRepository struct {
 }
 
 func QuayURLParse(hostname string) *url.URL {
-	if config.Hostname != "" {
-		hostname = config.Hostname
+	if config.QuayHostname != "" {
+		hostname = config.QuayHostname
 	}
 	u, err := url.Parse("https://" + hostname + "/api/v1/")
 	if err != nil {

--- a/quay/repository.go
+++ b/quay/repository.go
@@ -20,7 +20,7 @@ func ListRepository(namespace string, public bool, hostname string) (QuayReposit
 
 	u.Path = path.Join(u.Path, "repository")
 
-	body, err := utils.HttpGet(u.String()+"?"+values.Encode(), config.APIToken)
+	body, err := utils.HttpGet(u.String()+"?"+values.Encode(), config.QuayAPIToken)
 	if err != nil {
 		return repositories, err
 	}
@@ -45,7 +45,7 @@ func GetRepository(namespace string, name string, hostname string) (ResponseRepo
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name)
 
-	body, err := utils.HttpGet(u.String(), config.APIToken)
+	body, err := utils.HttpGet(u.String(), config.QuayAPIToken)
 	if err != nil {
 		return repos, err
 	}
@@ -61,7 +61,7 @@ func DeleteRepository(namespace string, name string, hostname string) error {
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository", namespace, name)
 
-	_, err := utils.HttpDelete(u.String(), config.APIToken)
+	_, err := utils.HttpDelete(u.String(), config.QuayAPIToken)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func CreateRepository(namespace string, name string, visibility string, hostname
 	u := QuayURLParse(hostname)
 	u.Path = path.Join(u.Path, "repository")
 
-	body, err := utils.HttpPost(u.String(), config.APIToken, req)
+	body, err := utils.HttpPost(u.String(), config.QuayAPIToken, req)
 	if err != nil {
 		return repos, err
 	}


### PR DESCRIPTION
## WHY

fix #42, #40 

If you set `HOSTNAME`, `qucli` use it instead of `QUAY_HOSTNAME`.

## WHAT

fix bug.

- before

```
$ docker run --rm -it --entrypoint sh  quay.io/koudaiii/qucli:latest
/ # env
HOSTNAME=5804df53becb
SHLVL=1
HOME=/root
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/
```

```
/ # /qucli list koudaiii
err: Get https://5804df53becb/api/v1/repository?namespace=koudaiii&public=true: dial tcp 172.17.0.2:443: getsockopt: connection refused

/ # QUAY_HOSTNAME=quay.io /qucli list koudaiii
NAME							isPublic	DESCRIPTION
quay.io/koudaiii/jtf2017				true		

/ # HOSTNAME=quay.io /qucli list koudaiii
NAME							isPublic	DESCRIPTION
quay.io/koudaiii/jtf2017				true		
```


- after

```
# do not use `HOSTNAME` env

$ HOSTNAME=hogehoge ./bin/qucli list koudaiii 
NAME							isPublic	DESCRIPTION
quay.io/koudaiii/jtf2017				true		

# you can `--hostname` flag

$ HOSTNAME=hogehoge ./bin/qucli list koudaiii --hostname=hogehoge
err: Get https://hogehoge/api/v1/repository?namespace=koudaiii&public=true: dial tcp: lookup hogehoge: no such host

# if you can set `QUAY_HOSTNAME`, qucli use `QUAY_HOSTNAME`

$ QUAY_HOSTNAME=hogehoge ./bin/qucli list koudaiii
err: Get https://hogehoge/api/v1/repository?namespace=koudaiii&public=true: dial tcp: lookup hogehoge: no such host
```