### PR TITLE
Bump up to v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.6 (2019-04-19)
+
+- [Fix bug] Default not use `HOSTNAME` env #44
+
 ## 0.6.5 (2017-10-18)
 
 - Add validate #37

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := qucli
-VERSION   := v0.6.5
+VERSION   := v0.6.6
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)


### PR DESCRIPTION
## WHY

- Releases [Fix bug] Default not use `HOSTNAME` env #44